### PR TITLE
rollup supports now vue "@" alias - e.g. '@/components/HelloWorld.vue'

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     },
     "devDependencies": {
         "@mdi/font": "^4.6.95",
+        "@rollup/plugin-alias": "^3.1.0",
         "@rollup/plugin-node-resolve": "^6.0.0",
         "@types/node": "^12.12.14",
         "@vue/cli-plugin-babel": "^4.1.1",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -16,6 +16,13 @@ import resolve from '@rollup/plugin-node-resolve';
 import del from 'rollup-plugin-delete'
 import css from 'rollup-plugin-css-porter';
 import sass from 'rollup-plugin-sass';
+import alias from '@rollup/plugin-alias'
+import path from 'path'
+
+const projectRootDir = path.resolve(__dirname)
+const customResolver = resolve({
+  extensions: ['.ts', '.js', '.vue', '.sass', '.scss']
+})
 
 export default {
     input: 'src/index.ts', // our source file
@@ -91,6 +98,15 @@ export default {
         }),
         sass(),
         css(),
+        alias({
+            entries: [
+              {
+                find: '@',
+                replacement: path.resolve(projectRootDir, 'src'),
+              }
+            ],
+            customResolver,
+        }),
         resolve(),
         // terser() // minifies generated bundles
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 // import Vuetify, { VBtn } from 'vuetify/lib';
 import Vue from 'vue';
-import HelloWorld from './components/HelloWorld.vue';
+import HelloWorld from '@/components/HelloWorld.vue';
 
 /**
  * Fügt eine "install" function bei MLiveForce hinzu


### PR DESCRIPTION
Developers often use `@` as alias of `src` folder in Vue. Rollup template supports with this fix  the default import syntax of Vue - e.g `@/components/HelloWorld.vue`. Developers **do not need anymore** to change `@/components/HelloWorld.vue` to `./components/HelloWorld.vue` everywhere to make rollup template work for their Vue project.